### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/EFRepository-Core-3_0/EFRepository-Core-3_0.csproj
+++ b/src/EFRepository-Core-3_0/EFRepository-Core-3_0.csproj
@@ -11,7 +11,16 @@
 		<RepositoryUrl>https://github.com/MindfireTechnology/EFRepository</RepositoryUrl>
 		<PackageTags>EF, EntityFramework, Entity Framework, Core, NetStandard, Repository Pattern</PackageTags>
 		<AssemblyName>EFRepositoryCore</AssemblyName>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<Compile Include="..\EFRepository\IRepository.cs" Link="IRepository.cs" />

--- a/src/EFRepository-Standard-2_0/EFRepository-Standard-2_0.csproj
+++ b/src/EFRepository-Standard-2_0/EFRepository-Standard-2_0.csproj
@@ -11,7 +11,16 @@
 		<RepositoryUrl>https://github.com/MindfireTechnology/EFRepository</RepositoryUrl>
 		<PackageTags>EF, EntityFramework, Entity Framework, Core, NetStandard, Repository Pattern</PackageTags>
 		<AssemblyName>EFRepositoryCore</AssemblyName>
-	</PropertyGroup>
+	
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 	<ItemGroup>
 		<Compile Include="..\EFRepository\IRepository.cs" Link="IRepository.cs" />

--- a/src/EFRepositoryCore/EFRepositoryCore.csproj
+++ b/src/EFRepositoryCore/EFRepositoryCore.csproj
@@ -13,7 +13,15 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/13372702?v=3&amp;s=200</PackageIconUrl>
     <RepositoryUrl>https://github.com/MindfireTechnology/EFRepository</RepositoryUrl>
     <PackageTags>EF, EntityFramework, Entity Framework, Core, NetStandard, Repository Pattern</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.4\EFRepositoryCore.xml</DocumentationFile>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
